### PR TITLE
Add org.freedesktop.Platform.GL32 extension

### DIFF
--- a/org.winepak.Sdk.yml
+++ b/org.winepak.Sdk.yml
@@ -18,6 +18,18 @@ add-extensions:
     autodelete: false
     no-autodownload: false
 
+  org.freedesktop.Platform.GL32:
+    directory: lib/32bit/lib/GL
+    version: 1.4
+    versions: 1.6;1.4
+    subdirectories: true
+    no-autodownload: true
+    autodelete: false
+    add-ld-path: lib
+    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d
+    download-if: active-gl-driver
+    enable-if: active-gl-driver
+
   org.winepak.Platform.Wine:
     directory: lib/wine
     version: 3.0


### PR DESCRIPTION
Add org.freedesktop.Platform.GL32 extension for 32bit nvidia libGL support on 64bit environment.
Based on [flathub's Steam flatpak](https://github.com/flathub/com.valvesoftware.Steam/blob/master/com.valvesoftware.Steam.json#L25)
Issue #14
This should fix https://github.com/winepak/applications/issues/37