### PR TITLE
Fix Visual C++ Redistributable Packages for Visual Studio Extensions

### DIFF
--- a/extension/org.winepak.Platform.Extension.vcrun2010.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2010.yml
@@ -15,6 +15,8 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d ${FLATPAK_DEST}/bin
+      - install apply_extra* ${FLATPAK_DEST}/bin
+      - install apply_extra ${FLATPAK_DEST}/bin
     sources:
       # https://www.microsoft.com/en-us/download/details.aspx?id=14632
       - type: extra-data
@@ -23,13 +25,103 @@ modules:
         url: https://download.microsoft.com/download/3/2/2/3224B87F-CFA0-4E70-BDA3-3DE650EFEBA5/vcredist_x64.exe
         size: 5718872
         sha256: b06546ddc8ca1e3d532f3f2593e88a6f49e81b66a9c2051d58508cc97b6a2023
-        filename: vcrun2010_x64.exe
+        filename: vc_redist.x64.exe
       # https://www.microsoft.com/en-us/download/details.aspx?id=5555
       - type: extra-data
         url: https://download.microsoft.com/download/5/B/C/5BC5DBB3-652D-4DCE-B14A-475AB85EEF6E/vcredist_x86.exe
         size: 5073240
         sha256: 8162b2d665ca52884507ede19549e99939ce4ea4a638c537fa653539819138c8
-        filename: vcrun2010_x86.exe
+        filename: vc_redist.x86.exe
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra64
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - i386
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra64
+        commands:
+          - OPERATION="vcrun2010"
+          - ARCH="x64"
+          - SOURCE_FILE="vc_redist.x64.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/*.cab
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_atl100_x64" "${DIR_DLLS}/atl100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc100_x64" "${DIR_DLLS}/mfc100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc100u_x64" "${DIR_DLLS}/mfc100u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm100_x64" "${DIR_DLLS}/mfcm100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm100u_x64" "${DIR_DLLS}/mfcm100u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcp100_x64" "${DIR_DLLS}/msvcp100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcr100_x64" "${DIR_DLLS}/msvcr100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcomp100_x64" "${DIR_DLLS}/vcomp100.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+      - type: script
+        dest-filename: apply_extra32
+        commands:
+          - OPERATION="vcrun2010"
+          - ARCH="x86"
+          - SOURCE_FILE="vc_redist.x86.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/*.cab
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_atl100_x86" "${DIR_DLLS}/atl100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc100_x86" "${DIR_DLLS}/mfc100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc100u_x86" "${DIR_DLLS}/mfc100u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm100_x86" "${DIR_DLLS}/mfcm100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm100u_x86" "${DIR_DLLS}/mfcm100u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcp100_x86" "${DIR_DLLS}/msvcp100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcr100_x86" "${DIR_DLLS}/msvcr100.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcomp100_x86" "${DIR_DLLS}/vcomp100.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+
 
   - name: scripts
     buildsystem: simple
@@ -45,23 +137,47 @@ modules:
           - '    echo "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine64 ${EXTENSION_DIR}/extra/vcrun2010_x64.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x64/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - x86_64
         dest-filename: vcrun2010-install64-wow64
         commands:
           - if [ -z "$WINEPREFIX" ] ; then
-          - '    echo "No wine prefix set or is empty, abort."'
+          - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2010_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - i386
@@ -71,10 +187,22 @@ modules:
           - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2010_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
 
   - name: metainfo
     buildsystem: simple

--- a/extension/org.winepak.Platform.Extension.vcrun2012.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2012.yml
@@ -15,6 +15,8 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d ${FLATPAK_DEST}/bin
+      - install apply_extra* ${FLATPAK_DEST}/bin
+      - install apply_extra ${FLATPAK_DEST}/bin
     sources:
       # https://www.microsoft.com/en-nz/download/details.aspx?id=30679
       - type: extra-data
@@ -23,13 +25,104 @@ modules:
         url: https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
         size: 7186992
         sha256: 681be3e5ba9fd3da02c09d7e565adfa078640ed66a0d58583efad2c1e3cc4064
-        filename: vcrun2012_x64.exe
+        filename: vc_redist.x64.exe
       # https://www.microsoft.com/en-nz/download/details.aspx?id=30679
       - type: extra-data
         url: https://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x86.exe
         size: 6554576
         sha256: b924ad8062eaf4e70437c8be50fa612162795ff0839479546ce907ffa8d6e386
-        filename: vcrun2012_x86.exe
+        filename: vc_redist.x86.exe
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra64
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - i386
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra64
+        commands:
+          - OPERATION="vcrun2012"
+          - ARCH="x64"
+          - SOURCE_FILE="vc_redist.x64.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a2
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a3
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_atl110_x64" "${DIR_DLLS}/atl110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc110_x64" "${DIR_DLLS}/mfc110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc110u_x64" "${DIR_DLLS}/mfc110u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcp110_x64" "${DIR_DLLS}/msvcp110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcr110_x64" "${DIR_DLLS}/msvcr110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcomp110_x64" "${DIR_DLLS}/vcomp110.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+      - type: script
+        dest-filename: apply_extra32
+        commands:
+          - OPERATION="vcrun2012"
+          - ARCH="x86"
+          - SOURCE_FILE="vc_redist.x86.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a2
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a3
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_atl110_x86" "${DIR_DLLS}/atl110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc110_x86" "${DIR_DLLS}/mfc110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc110u_x86" "${DIR_DLLS}/mfc110u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm110_x86" "${DIR_DLLS}/mfcm110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm110u_x86" "${DIR_DLLS}/mfcm110u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcp110_x86" "${DIR_DLLS}/msvcp110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcr110_x86" "${DIR_DLLS}/msvcr110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcamp110_x86" "${DIR_DLLS}/vcamp110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vccorlib110_x86" "${DIR_DLLS}/vccorlib110.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcomp110_x86" "${DIR_DLLS}/vcomp110.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
 
   - name: scripts
     buildsystem: simple
@@ -45,23 +138,47 @@ modules:
           - '    echo "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine64 ${EXTENSION_DIR}/extra/vcrun2012_x64.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x64/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - x86_64
         dest-filename: vcrun2012-install64-wow64
         commands:
           - if [ -z "$WINEPREFIX" ] ; then
-          - '    echo "No wine prefix set or is empty, abort."'
+          - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2012_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - i386
@@ -71,10 +188,22 @@ modules:
           - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2012_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
 
   - name: metainfo
     buildsystem: simple

--- a/extension/org.winepak.Platform.Extension.vcrun2013.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2013.yml
@@ -15,6 +15,8 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d ${FLATPAK_DEST}/bin
+      - install apply_extra* ${FLATPAK_DEST}/bin
+      - install apply_extra ${FLATPAK_DEST}/bin
     sources:
       # https://www.microsoft.com/en-us/download/details.aspx?id=40784
       - type: extra-data
@@ -23,13 +25,104 @@ modules:
         url: https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x64.exe
         size: 7194312
         sha256: e554425243e3e8ca1cd5fe550db41e6fa58a007c74fad400274b128452f38fb8
-        filename: vcrun2013_x64.exe
+        filename: vc_redist.x64.exe
       # https://www.microsoft.com/en-us/download/details.aspx?id=40784
       - type: extra-data
         url: https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe
         size: 6503984
         sha256: a22895e55b26202eae166838edbe2ea6aad00d7ea600c11f8a31ede5cbce2048
-        filename: vcrun2013_x86.exe
+        filename: vc_redist.x86.exe
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra64
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - i386
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra64
+        commands:
+          - OPERATION="vcrun2013"
+          - ARCH="x64"
+          - SOURCE_FILE="vc_redist.x64.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a2
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a3
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc120_x64" "${DIR_DLLS}/mfc120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc120u_x64" "${DIR_DLLS}/mfc120u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm120_x64" "${DIR_DLLS}/mfcm12.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm120u_x64" "${DIR_DLLS}/mfcm120u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcp120_x64" "${DIR_DLLS}/msvcp120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcr120_x64" "${DIR_DLLS}/msvcr120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcomp120_x64" "${DIR_DLLS}/vcomp120.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+      - type: script
+        dest-filename: apply_extra32
+        commands:
+          - OPERATION="vcrun2013"
+          - ARCH="x86"
+          - SOURCE_FILE="vc_redist.x86.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a2
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a3
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc120_x86" "${DIR_DLLS}/mfc120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfc120u_x86" "${DIR_DLLS}/mfc120u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm120_x86" "${DIR_DLLS}/mfcm12.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_mfcm120u_x86" "${DIR_DLLS}/mfcm120u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcp120_x86" "${DIR_DLLS}/msvcp120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_msvcr120_x86" "${DIR_DLLS}/msvcr120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcamp120_x86" "${DIR_DLLS}/vcamp120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vccorlib120_x86" "${DIR_DLLS}/vccorlib120.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/f_central_vcomp120_x86" "${DIR_DLLS}/vcomp120.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
 
   - name: scripts
     buildsystem: simple
@@ -45,23 +138,47 @@ modules:
           - '    echo "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine64 ${EXTENSION_DIR}/extra/vcrun2013_x64.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x64/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - x86_64
         dest-filename: vcrun2013-install64-wow64
         commands:
           - if [ -z "$WINEPREFIX" ] ; then
-          - '    echo "No wine prefix set or is empty, abort."'
+          - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2013_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - i386
@@ -71,10 +188,22 @@ modules:
           - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2013_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
 
   - name: metainfo
     buildsystem: simple

--- a/extension/org.winepak.Platform.Extension.vcrun2013.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2013.yml
@@ -169,7 +169,7 @@ modules:
           - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
           - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
           - 
-          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
           - do
           - '    filename=${dll##*/}'
           - '    name=${filename%.dll}'
@@ -194,7 +194,7 @@ modules:
           - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
           - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
           - 
-          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
           - do
           - '    filename=${dll##*/}'
           - '    name=${filename%.dll}'

--- a/extension/org.winepak.Platform.Extension.vcrun2015.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2015.yml
@@ -15,6 +15,8 @@ modules:
     buildsystem: simple
     build-commands:
       - install -d ${FLATPAK_DEST}/bin
+      - install apply_extra* ${FLATPAK_DEST}/bin
+      - install apply_extra ${FLATPAK_DEST}/bin
     sources:
       # https://www.microsoft.com/en-us/download/details.aspx?id=48145
       - type: extra-data
@@ -23,13 +25,122 @@ modules:
         url: https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe
         size: 14572000
         sha256: 5eea714e1f22f1875c1cb7b1738b0c0b1f02aec5ecb95f0fdb1c5171c6cd93a3
-        filename: vcrun2015_x64.exe
+        filename: vc_redist.x64.exe
       # https://www.microsoft.com/en-us/download/details.aspx?id=48145
       - type: extra-data
         url: https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x86.exe
         size: 13767776
         sha256: fdd1e1f0dcae2d0aa0720895eff33b927d13076e64464bb7c7e5843b7667cd14
-        filename: vcrun2015_x86.exe
+        filename: vc_redist.x86.exe
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra64
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - i386
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra64
+        commands:
+          - OPERATION="vcrun2015"
+          - ARCH="x64"
+          - SOURCE_FILE="vc_redist.x64.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a10
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a11
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/concrt140.dll" "${DIR_DLLS}/concrt140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140.dll" "${DIR_DLLS}/mfc140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140u.dll" "${DIR_DLLS}/mfc140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140.dll" "${DIR_DLLS}/mfcm140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140u.dll" "${DIR_DLLS}/mfcm140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/msvcp140.dll" "${DIR_DLLS}/msvcp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcamp140.dll" "${DIR_DLLS}/vcamp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vccorlib140.dll" "${DIR_DLLS}/vccorlib140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcomp140.dll" "${DIR_DLLS}/vcomp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcruntime140.dll" "${DIR_DLLS}/vcruntime140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_conio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-conio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_heap_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-heap-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_locale_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-locale-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_math_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-math-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_runtime_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-runtime-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_stdio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-stdio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/ucrtbase.dll" "${DIR_DLLS}/ucrtbase.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+      - type: script
+        dest-filename: apply_extra32
+        commands:
+          - OPERATION="vcrun2015"
+          - ARCH="x86"
+          - SOURCE_FILE="vc_redist.x86.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a10
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a11
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/concrt140.dll" "${DIR_DLLS}/concrt140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140.dll" "${DIR_DLLS}/mfc140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140u.dll" "${DIR_DLLS}/mfc140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140.dll" "${DIR_DLLS}/mfcm140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140u.dll" "${DIR_DLLS}/mfcm140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/msvcp140.dll" "${DIR_DLLS}/msvcp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcamp140.dll" "${DIR_DLLS}/vcamp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vccorlib140.dll" "${DIR_DLLS}/vccorlib140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcomp140.dll" "${DIR_DLLS}/vcomp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcruntime140.dll" "${DIR_DLLS}/vcruntime140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_conio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-conio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_heap_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-heap-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_locale_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-locale-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_math_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-math-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_runtime_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-runtime-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_stdio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-stdio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/ucrtbase.dll" "${DIR_DLLS}/ucrtbase.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
 
   - name: scripts
     buildsystem: simple
@@ -45,23 +156,47 @@ modules:
           - '    echo "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine64 ${EXTENSION_DIR}/extra/vcrun2015_x64.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x64/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - x86_64
         dest-filename: vcrun2015-install64-wow64
         commands:
           - if [ -z "$WINEPREFIX" ] ; then
-          - '    echo "No wine prefix set or is empty, abort."'
+          - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2015_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
       - type: script
         only-arches:
           - i386
@@ -71,10 +206,22 @@ modules:
           - '    "No wine prefix set or is empty, abort."'
           - '    exit 1'
           - fi
-          - ''
+          - 
           - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
-          - ''
-          - wine ${EXTENSION_DIR}/extra/vcrun2015_x86.exe /q
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
 
   - name: metainfo
     buildsystem: simple

--- a/extension/org.winepak.Platform.Extension.vcrun2015.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2015.yml
@@ -187,7 +187,7 @@ modules:
           - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
           - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
           - 
-          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
           - do
           - '    filename=${dll##*/}'
           - '    name=${filename%.dll}'
@@ -212,7 +212,7 @@ modules:
           - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
           - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
           - 
-          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
           - do
           - '    filename=${dll##*/}'
           - '    name=${filename%.dll}'

--- a/extension/org.winepak.Platform.Extension.vcrun2017.metainfo.xml
+++ b/extension/org.winepak.Platform.Extension.vcrun2017.metainfo.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+    <id>org.winepak.Platform.Extension.vcrun2017</id>
+    <extends>org.winepak.Platform.desktop</extends>
+    <metadata_license>CC0-1.0</metadata_license>
+    <project_license>LicenseRef-proprietary</project_license>
+    <name>Visual C++ Redistributable Packages for Visual Studio 2017</name>
+    <summary>Add Visual C++ Redistributable Packages for Visual Studio 2017 support to an application</summary>
+</component>

--- a/extension/org.winepak.Platform.Extension.vcrun2017.yml
+++ b/extension/org.winepak.Platform.Extension.vcrun2017.yml
@@ -1,0 +1,234 @@
+build-extension: true
+
+id: org.winepak.Platform.Extension.vcrun2017
+branch: 3.0
+
+runtime: org.winepak.Platform
+runtime-version: 3.0
+sdk: org.winepak.Sdk
+
+separate-locales: false
+appstream-compose: false
+
+modules:
+  - name: vcrun2017
+    buildsystem: simple
+    build-commands:
+      - install -d ${FLATPAK_DEST}/bin
+      - install apply_extra* ${FLATPAK_DEST}/bin
+      - install apply_extra ${FLATPAK_DEST}/bin
+    sources:
+      # https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads
+      - type: extra-data
+        only-arches:
+          - x86_64
+        url: https://aka.ms/vs/15/release/vc_redist.x64.exe
+        size: 15244952
+        sha256: 9abf3a1386584ea0e4b31198cc56e988e13e67ccdb1137ec6e18e883753d2ddb
+        filename: vc_redist.x64.exe
+      # https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads
+      - type: extra-data
+        url: https://aka.ms/vs/15/release/vc_redist.x86.exe
+        size: 14611496
+        sha256: eb5f74215e4308d8f2b1d458e78f33050a779b9be19baaa2174de1be9be1b830
+        filename: vc_redist.x86.exe
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra64
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - i386
+        dest-filename: apply_extra
+        commands:
+          - /app/bin/apply_extra32
+          - 
+          - rm -rf extracted
+          - rm -rf extracted_dlls
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: apply_extra64
+        commands:
+          - OPERATION="vcrun2017"
+          - ARCH="x64"
+          - SOURCE_FILE="vc_redist.x64.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a10
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a11
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/concrt140.dll" "${DIR_DLLS}/concrt140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140.dll" "${DIR_DLLS}/mfc140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140u.dll" "${DIR_DLLS}/mfc140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140.dll" "${DIR_DLLS}/mfcm140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140u.dll" "${DIR_DLLS}/mfcm140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/msvcp140.dll" "${DIR_DLLS}/msvcp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcamp140.dll" "${DIR_DLLS}/vcamp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vccorlib140.dll" "${DIR_DLLS}/vccorlib140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcomp140.dll" "${DIR_DLLS}/vcomp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcruntime140.dll" "${DIR_DLLS}/vcruntime140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_conio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-conio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_heap_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-heap-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_locale_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-locale-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_math_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-math-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_runtime_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-runtime-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_stdio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-stdio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/ucrtbase.dll" "${DIR_DLLS}/ucrtbase.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+      - type: script
+        dest-filename: apply_extra32
+        commands:
+          - OPERATION="vcrun2017"
+          - ARCH="x86"
+          - SOURCE_FILE="vc_redist.x86.exe"
+          - DIR_EXTRACTED="extracted/${ARCH}"
+          - DIR_EXTRACTED_DLLS="extracted_dlls/${ARCH}"
+          - DIR_DLLS="dlls/${ARCH}"
+          - 
+          - mkdir -p $DIR_EXTRACTED
+          - mkdir -p $DIR_EXTRACTED_DLLS
+          - mkdir -p $DIR_DLLS
+          - 
+          - echo "${OPERATION} (${ARCH}): Extracting redistributable"
+          - cabextract -q -d $DIR_EXTRACTED -L $SOURCE_FILE
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a10
+          - cabextract -q -d $DIR_EXTRACTED_DLLS -L ${DIR_EXTRACTED}/a11
+          - 
+          - # Grab the DLLs we need and correct naming
+          - echo "${OPERATION} (${ARCH}): Saving and renaming the correct DLLs"
+          - mv "${DIR_EXTRACTED_DLLS}/concrt140.dll" "${DIR_DLLS}/concrt140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140.dll" "${DIR_DLLS}/mfc140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfc140u.dll" "${DIR_DLLS}/mfc140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140.dll" "${DIR_DLLS}/mfcm140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/mfcm140u.dll" "${DIR_DLLS}/mfcm140u.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/msvcp140.dll" "${DIR_DLLS}/msvcp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcamp140.dll" "${DIR_DLLS}/vcamp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vccorlib140.dll" "${DIR_DLLS}/vccorlib140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcomp140.dll" "${DIR_DLLS}/vcomp140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/vcruntime140.dll" "${DIR_DLLS}/vcruntime140.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_conio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-conio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_heap_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-heap-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_locale_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-locale-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_math_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-math-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_runtime_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-runtime-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/api_ms_win_crt_stdio_l1_1_0.dll" "${DIR_DLLS}/api-ms-win-crt-stdio-l1-1-0.dll"
+          - mv "${DIR_EXTRACTED_DLLS}/ucrtbase.dll" "${DIR_DLLS}/ucrtbase.dll"
+          - 
+          - # Clean-up
+          - echo "${OPERATION} (${ARCH}): Cleaning-up"
+          - rm -rf $DIR_EXTRACTED
+          - rm -rf $DIR_EXTRACTED_DLLS
+          - rm $SOURCE_FILE
+
+  - name: scripts
+    buildsystem: simple
+    build-commands:
+      - install vcrun2017-install* ${FLATPAK_DEST}/bin
+    sources:
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: vcrun2017-install64
+        commands:
+          - if [ -z "$WINEPREFIX" ] ; then
+          - '    echo "No wine prefix set or is empty, abort."'
+          - '    exit 1'
+          - fi
+          - 
+          - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x64/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x64/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
+      - type: script
+        only-arches:
+          - x86_64
+        dest-filename: vcrun2017-install64-wow64
+        commands:
+          - if [ -z "$WINEPREFIX" ] ; then
+          - '    "No wine prefix set or is empty, abort."'
+          - '    exit 1'
+          - fi
+          - 
+          - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/syswow64/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine64 reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
+      - type: script
+        only-arches:
+          - i386
+        dest-filename: vcrun2017-install32
+        commands:
+          - if [ -z "$WINEPREFIX" ] ; then
+          - '    "No wine prefix set or is empty, abort."'
+          - '    exit 1'
+          - fi
+          - 
+          - EXTENSION_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" && pwd )"
+          - 
+          - mkdir -p "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - cp ${EXTENSION_DIR}/extra/dlls/x86/*.dll "${WINEPREFIX}/dosdevices/c:/windows/system32/"
+          - 
+          - for dll in ${EXTENSION_DIR}/extra/dlls/x86/*.dll
+          - do
+          - '    filename=${dll##*/}'
+          - '    name=${filename%.dll}'
+          - 
+          - '    echo "[REGEDIT] Adding:"'
+          - '    echo "HKEY_CURRENT_USER\Software\Wine\DllOverrides"'
+          - '    echo "${name}=native,builtin"'
+          - '    wine reg add ''HKEY_CURRENT_USER\Software\Wine\DllOverrides'' /v ${name} /d native,builtin /f'
+          - done
+
+  - name: metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.winepak.Platform.Extension.vcrun2017.metainfo.xml
+      - appstream-compose --basename=org.winepak.Platform.Extension.vcrun2017 --prefix=${FLATPAK_DEST} --origin=flatpak org.winepak.Platform.Extension.vcrun2017
+    sources:
+      - type: file
+        path: org.winepak.Platform.Extension.vcrun2017.metainfo.xml
+


### PR DESCRIPTION
The Visual C++ Redistributable Packages for Visual Studio 64 bit extensions didn't correctly install files. This pr changes each extension so that it manually installs the files by extracting the DLLs from the exe/cabs instead of using the included installer.

Fixes:
- vcrun2010
- vcrun2012
- vcrun2013
- vcrun2015

Adds:
- vcrun2017