### PR TITLE
[org.winepak.Platform.Wine] Add 3.15-staging branch

### DIFF
--- a/wine/3.15-staging/org.winepak.Platform.Wine.metainfo.xml
+++ b/wine/3.15-staging/org.winepak.Platform.Wine.metainfo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+    <id>org.winepak.Platform.Wine</id>
+    <extends>org.winepak.Platform.desktop</extends>
+    <metadata_license>CC0-1.0</metadata_license>
+    <name>Wine Staging</name>
+    <summary>Add Wine Staging to the winepak Platform</summary>
+</component>

--- a/wine/3.15-staging/org.winepak.Platform.Wine.yml
+++ b/wine/3.15-staging/org.winepak.Platform.Wine.yml
@@ -1,0 +1,104 @@
+build-extension: true
+
+id: org.winepak.Platform.Wine
+branch: 3.15-staging
+
+runtime: org.winepak.Platform
+runtime-version: 3.0
+sdk: org.winepak.Sdk
+
+separate-locales: false
+appstream-compose: false
+
+cleanup:
+  - /man
+  - /share/man
+
+build-options:
+  cflags: -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2
+  cxxflags: -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2
+  ldflags: -fstack-protector-strong -Wl,-z,relro,-z,now
+  prefix: "${FLATPAK_DEST}"
+  env:
+    V: '1'
+
+modules:
+  - name: wine-staging-win64
+    only-arches:
+      - x86_64
+    config-opts:
+      - --enable-win64
+      - --disable-win16
+      - --disable-tests
+      - --with-x
+      - --with-ldap
+      - --with-netapi
+      - --without-cups
+      - --without-curses
+      - --without-capi
+      - --without-glu
+      - --without-gphoto
+      - --without-gsm
+      - --without-hal
+      - --without-opencl
+      - --without-pcap
+      - --without-udev
+      - --without-v4l
+    cleanup:
+      - /share/man
+      - /share/applications
+    sources:
+      - type: archive
+        url: https://dl.winehq.org/wine/source/3.x/wine-3.15.tar.xz
+        sha256: 2ca2cd95b69f2d89aaa481db34db20cbb249c6aba28ad77ecf383270326ab51e
+      - type: archive
+        url: https://github.com/wine-staging/wine-staging/archive/v3.15.tar.gz
+        sha256: bf209bf102455938ef0b8f678c2c68f134746aef633fbdf56a9c1994309349c4
+      - type: shell
+        commands:
+          - ./patches/patchinstall.sh DESTDIR=$(pwd) --all
+
+  - name: wine-staging-win32
+    only-arches:
+      - i386
+    config-opts:
+      - --disable-win64
+      - --disable-win16
+      - --disable-tests
+      - --with-x
+      - --with-ldap
+      - --with-netapi
+      - --without-cups
+      - --without-curses
+      - --without-capi
+      - --without-glu
+      - --without-gphoto
+      - --without-gsm
+      - --without-hal
+      - --without-opencl
+      - --without-pcap
+      - --without-udev
+    cleanup:
+      - /bin/function_grep.pl
+      - /include
+      - /share/man
+      - /share/applications
+    sources:
+      - type: archive
+        url: https://dl.winehq.org/wine/source/3.x/wine-3.15.tar.xz
+        sha256: 2ca2cd95b69f2d89aaa481db34db20cbb249c6aba28ad77ecf383270326ab51e
+      - type: archive
+        url: https://github.com/wine-staging/wine-staging/archive/v3.15.tar.gz
+        sha256: bf209bf102455938ef0b8f678c2c68f134746aef633fbdf56a9c1994309349c4
+      - type: shell
+        commands:
+          - ./patches/patchinstall.sh DESTDIR=$(pwd) --all
+
+  - name: metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.winepak.Platform.Wine.metainfo.xml
+      - appstream-compose --basename=org.winepak.Platform.Wine --prefix=${FLATPAK_DEST} --origin=flatpak org.winepak.Platform.Wine
+    sources:
+      - type: file
+        path: org.winepak.Platform.Wine.metainfo.xml


### PR DESCRIPTION
Add Wine 3.15-staging branch needed for run League of Legends after the anti-cheat patch.