### PR TITLE
Some fixes to redesign branch

### DIFF
--- a/org.winepak.Sdk.yml
+++ b/org.winepak.Sdk.yml
@@ -128,6 +128,11 @@ build-options:
   ldflags: -fstack-protector-strong -Wl,-z,relro,-z,now
   env:
     V: '1'
+  arch:
+    x86_64:
+      libdir: /usr/lib/x86_64-linux-gnu
+    i386:
+      libdir: /usr/lib/i386-linux-gnu
 
 modules:
   - name: platform-setup

--- a/org.winepak.Sdk.yml
+++ b/org.winepak.Sdk.yml
@@ -74,7 +74,7 @@ add-extensions:
     autodelete: true
 
   org.freedesktop.Platform.GL32:
-    directory: lib/i386-linux-gnu/lib/GL
+    directory: lib/i386-linux-gnu/GL
     version: 1.4
     versions: 1.6;1.4
     add-ld-path: lib

--- a/org.winepak.Sdk.yml
+++ b/org.winepak.Sdk.yml
@@ -169,11 +169,16 @@ modules:
         url: https://www.rarlab.com/rar/unrarsrc-5.6.4.tar.gz
         sha256: 9335d2201870f2034007c04be80e00f1dc23932cb88b329d55c76134e6ba49fe
 
-  - name: wine-win64
-    only-arches:
-      - x86_64
+  - name: wine
+    build-options:
+      arch:
+        x86_64:
+          config-opts:
+            - --enable-win64
+        i386:
+          config-opts:
+            - --disable-win64
     config-opts:
-      - --enable-win64
       - --disable-win16
       - --disable-tests
       - --with-x
@@ -203,42 +208,11 @@ modules:
       - rm -rf /usr/share/wine/mono
       - ln -s /usr/lib/mono /usr/share/wine/mono
 
-  - name: wine-win32
+  - name: wine-compat
     only-arches:
       - i386
-    config-opts:
-      - --disable-win64
-      - --disable-win16
-      - --disable-tests
-      - --with-x
-      - --with-ldap
-      - --without-cups
-      - --without-curses
-      - --without-capi
-      - --without-glu
-      - --without-gphoto
-      - --without-gsm
-      - --without-hal
-      - --without-netapi
-      - --without-opencl
-      - --without-pcap
-      - --without-udev
-      - --without-v4l
-    cleanup:
-      - /bin/function_grep.pl
-      - /include
-      - /share/man
-      - /share/applications
-    sources:
-      - type: archive
-        url: https://dl.winehq.org/wine/source/3.0/wine-3.0.2.tar.xz
-        sha256: cad771375409e24244eab252da044306158af8a8bea4432e7ca81c1dc6b463ff
-    post-install:
-      - rm -rf /usr/share/wine/gecko
-      - ln -s /usr/lib/gecko /usr/share/wine/gecko
-      - rm -rf /usr/share/wine/mono
-      - ln -s /usr/lib/mono /usr/share/wine/mono
-      - 
+    buildsystem: simple
+    build-commands:
       - mkdir -p /usr/lib/i386-linux-gnu/wine/bin
       - |
         for i in /usr/bin/wine*; do

--- a/org.winepak.Sdk.yml
+++ b/org.winepak.Sdk.yml
@@ -207,6 +207,32 @@ modules:
       - ln -s /usr/lib/gecko /usr/share/wine/gecko
       - rm -rf /usr/share/wine/mono
       - ln -s /usr/lib/mono /usr/share/wine/mono
+      - |
+        case $FLATPAK_ARCH in
+          x86_64)
+            mv $FLATPAK_DEST/bin/wineserver{,64}
+          ;;
+          i386)
+            mv $FLATPAK_DEST/bin/wineserver{,32}
+          ;;
+        esac
+
+  - name: wineserver-wrapper
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 wineserver.sh /usr/bin/wineserver
+    sources:
+      - type: script
+        dest-filename: wineserver.sh
+        commands:
+          - |
+            if command -v wineserver64; then
+              exec wineserver64 $@
+            elif command -v wineserver32; then
+              exec wineserver32 $@
+            else
+              exit 1
+            fi
 
   - name: wine-compat
     only-arches:


### PR DESCRIPTION
Some steps towards #12
- We can add conditional `config-opts` dependent on arch, so there is really no need for separate wine32/wine64 modules
- We should make sure that we always launch 64-bit wineserver if we are on 64-bit arch