### PR TITLE
Added Ansible automation to add new Wine builds easily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .flatpak-builder
 builds
 winepak
+*.retry

--- a/README.md
+++ b/README.md
@@ -71,3 +71,14 @@ If you built Compat32/WoW64 support install those as well:
 
 ### Building an application
 See [winepak/applications](https://github.com/winepak/applications).
+
+
+## [Extra] Add the new version of Wine-staging automatically using ansible
+
+Just run:
+
+```bash
+ansible-playbook ansible_add_latest_staging.yaml
+```
+
+It should add the newest version of Wine-staging to ./wine at this repo, ready for a pull request.

--- a/ansible_add_latest_staging.yaml
+++ b/ansible_add_latest_staging.yaml
@@ -1,0 +1,31 @@
+- name: Update winepak
+  hosts: localhost
+  vars:
+    - winepak_runtime_version: "3.0"
+  tasks:
+  - name: Get list of tags
+    uri:
+      url: "https://api.github.com/repos/wine-staging/wine-staging/tags"
+    register: tags
+
+  - name: Set fact for latest tag
+    set_fact:
+      latest_tag_name: "{{ tags.json[0].name }}"
+    when: latest_tag_name is not defined
+
+  - name: Get wine files data
+    include_role:
+      name: "ansible_roles/get-wine-files-data"
+    vars:
+      tag_name: "{{ latest_tag_name }}"
+
+  - name: Debug
+    debug:
+      msg: "wine_staging_url: {{ wine_staging_url }};wine_src_url: {{ wine_src_url }};wine_src_sha256: {{ wine_src_sha256 }}\nwine_staging_sha256: {{ wine_staging_sha256 }}"
+      
+  - name: Build winepak build files
+    include_role:
+      name: "ansible_roles/create-wine-sdk-yaml"
+    vars:
+      tag_name: "{{ latest_tag_name }}"
+      output_dir: "wine/{{ latest_tag_name[1:] }}-staging/"

--- a/ansible_roles/create-wine-sdk-yaml/README.md
+++ b/ansible_roles/create-wine-sdk-yaml/README.md
@@ -1,0 +1,45 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+tag_name: Name of the Wine tag at GitHub we are working with (ex: "v4.2")
+winepak_runtime_version: Version of the winepak runtime to be used
+wine_src_url: Url of the .tar.xz file containing the wine source code (Provided by the module get_wine_files_data)
+wine_src_sha256: sha256 hash of the file at wine_src_url (Provided by the module get_wine_files_data)
+wine_staging_url: Url of the .tar.gz file containing the wine staging patching scripts (Provided by the module get_wine_files_data)
+wine_staging_sha256: sha256 hash of the file at wine_staging_url (Provided by the module get_wine_files_data)
+
+
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/ansible_roles/create-wine-sdk-yaml/meta/main.yml
+++ b/ansible_roles/create-wine-sdk-yaml/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible_roles/create-wine-sdk-yaml/tasks/main.yml
+++ b/ansible_roles/create-wine-sdk-yaml/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+# tasks file for create-wine-sdk-yaml
+#
+- name: "Ensure {{ output_dir }} exists"
+  file:
+    state: directory
+    path: "{{ output_dir }}"
+- name: "Create {{ metainfo_filename }}"
+  template:
+    src: "{{ metainfo_filename }}"
+    dest: "{{ output_dir }}"
+
+- name: "Create {{ build_filename }}"
+  template:
+    src: "{{ build_filename }}"
+    dest: "{{ output_dir }}"

--- a/ansible_roles/create-wine-sdk-yaml/templates/org.winepak.Platform.Wine.metainfo.xml
+++ b/ansible_roles/create-wine-sdk-yaml/templates/org.winepak.Platform.Wine.metainfo.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+    <id>org.winepak.Platform.Wine</id>
+    <extends>org.winepak.Platform.desktop</extends>
+    <metadata_license>CC0-1.0</metadata_license>
+    <name>Wine Staging</name>
+    <summary>Add Wine Staging to the winepak Platform</summary>
+</component>

--- a/ansible_roles/create-wine-sdk-yaml/templates/org.winepak.Platform.Wine.yml
+++ b/ansible_roles/create-wine-sdk-yaml/templates/org.winepak.Platform.Wine.yml
@@ -1,0 +1,105 @@
+build-extension: true
+
+# tag_name must be the tag
+id: org.winepak.Platform.Wine
+branch: "{{ tag_name[1:] }}"-staging
+
+runtime: org.winepak.Platform
+runtime-version: "{{ winepak_runtime_version }}"
+sdk: org.winepak.Sdk
+
+separate-locales: false
+appstream-compose: false
+
+cleanup:
+  - /man
+  - /share/man
+
+build-options:
+  cflags: -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2
+  cxxflags: -O2 -g -fstack-protector-strong -D_FORTIFY_SOURCE=2
+  ldflags: -fstack-protector-strong -Wl,-z,relro,-z,now
+  prefix: "${FLATPAK_DEST}"
+  env:
+    V: '1'
+
+modules:
+  - name: wine-staging-win64
+    only-arches:
+      - x86_64
+    config-opts:
+      - --enable-win64
+      - --disable-win16
+      - --disable-tests
+      - --with-x
+      - --with-ldap
+      - --with-netapi
+      - --without-cups
+      - --without-curses
+      - --without-capi
+      - --without-glu
+      - --without-gphoto
+      - --without-gsm
+      - --without-hal
+      - --without-opencl
+      - --without-pcap
+      - --without-udev
+      - --without-v4l
+    cleanup:
+      - /share/man
+      - /share/applications
+    sources:
+      - type: archive
+        url: "{{ wine_src_url }}"
+        sha256: "{{ wine_src_sha256 }}"
+      - type: archive
+        url: "{{ wine_staging_url }}"
+        sha256: "{{ wine_staging_sha256 }}"
+      - type: shell
+        commands:
+          - ./patches/patchinstall.sh DESTDIR=$(pwd) --all
+
+  - name: wine-staging-win32
+    only-arches:
+      - i386
+    config-opts:
+      - --disable-win64
+      - --disable-win16
+      - --disable-tests
+      - --with-x
+      - --with-ldap
+      - --with-netapi
+      - --without-cups
+      - --without-curses
+      - --without-capi
+      - --without-glu
+      - --without-gphoto
+      - --without-gsm
+      - --without-hal
+      - --without-opencl
+      - --without-pcap
+      - --without-udev
+    cleanup:
+      - /bin/function_grep.pl
+      - /include
+      - /share/man
+      - /share/applications
+    sources:
+      - type: archive
+        url: "{{ wine_src_url }}"
+        sha256: "{{ wine_src_sha256 }}"
+      - type: archive
+        url: "{{ wine_staging_url }}"
+        sha256: "{{ wine_staging_sha256 }}"
+      - type: shell
+        commands:
+          - ./patches/patchinstall.sh DESTDIR=$(pwd) --all
+
+  - name: metainfo
+    buildsystem: simple
+    build-commands:
+      - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.winepak.Platform.Wine.metainfo.xml
+      - appstream-compose --basename=org.winepak.Platform.Wine --prefix=${FLATPAK_DEST} --origin=flatpak org.winepak.Platform.Wine
+    sources:
+      - type: file
+path: org.winepak.Platform.Wine.metainfo.xml

--- a/ansible_roles/create-wine-sdk-yaml/tests/inventory
+++ b/ansible_roles/create-wine-sdk-yaml/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible_roles/create-wine-sdk-yaml/tests/test.yml
+++ b/ansible_roles/create-wine-sdk-yaml/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - create-wine-sdk-yaml

--- a/ansible_roles/create-wine-sdk-yaml/vars/main.yml
+++ b/ansible_roles/create-wine-sdk-yaml/vars/main.yml
@@ -1,0 +1,4 @@
+---
+# vars file for create-wine-sdk-yaml
+metainfo_filename: "org.winepak.Platform.Wine.metainfo.xml"
+build_filename: "org.winepak.Platform.Wine.yml"

--- a/ansible_roles/get-wine-files-data/README.md
+++ b/ansible_roles/get-wine-files-data/README.md
@@ -1,0 +1,26 @@
+Role Name
+=========
+
+Requires the variables
+
+- tag_name
+
+Tag name of the wine version we are working with
+
+Produces the variables:
+
+- wine_staging_url
+
+(Url to download the .tar.xz file of the latest version of wine-staging)
+
+- wine_src_url
+
+(Url to download the .tar.xz file of the latest version of wine)
+
+- wine_src_sha256
+
+sha256 checksum of the wine source code file
+
+- wine_staging_sha256
+
+sha256 checksum of the wine staging source code file

--- a/ansible_roles/get-wine-files-data/defaults/main.yml
+++ b/ansible_roles/get-wine-files-data/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# defaults file for get_wine_files_data
+wine_url_base: "https://dl.winehq.org/wine/source"
+wine_staging_url_base: "https://github.com/wine-staging/wine-staging/archive"
+wine_src_path: "/tmp/wine.tar.xz"
+wine_staging_path: "/tmp/wine-staging.tar.gz"

--- a/ansible_roles/get-wine-files-data/meta/main.yml
+++ b/ansible_roles/get-wine-files-data/meta/main.yml
@@ -1,0 +1,60 @@
+galaxy_info:
+  author: your name
+  description: your description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Some suggested licenses:
+  # - BSD (default)
+  # - MIT
+  # - GPLv2
+  # - GPLv3
+  # - Apache
+  # - CC-BY
+  license: license (GPLv2, CC-BY, etc)
+
+  min_ansible_version: 2.4
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  # Optionally specify the branch Galaxy will use when accessing the GitHub
+  # repo for this role. During role install, if no tags are available,
+  # Galaxy will use this branch. During import Galaxy will access files on
+  # this branch. If Travis integration is configured, only notifications for this
+  # branch will be accepted. Otherwise, in all cases, the repo's default branch
+  # (usually master) will be used.
+  #github_branch:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible_roles/get-wine-files-data/tasks/main.yml
+++ b/ansible_roles/get-wine-files-data/tasks/main.yml
@@ -1,0 +1,41 @@
+---
+# tasks file for get_wine_files_data
+- name: Generate Wine-staging src file URL
+  set_fact:
+    wine_staging_url: "{{ wine_staging_url_base }}/{{ tag_name }}.tar.gz"
+
+- name: Generate the Wine src file URL
+  set_fact:
+    wine_src_url: "{{ wine_url_base }}/{{ tag_name[1] }}.x/wine-{{ tag_name[1:] }}.tar.xz"
+
+- name: Download wine-staging patches file
+  get_url:
+    url: "{{ wine_staging_url }}"
+    dest: "{{ wine_staging_path }}"
+
+- name: Download wine source file
+  get_url:
+    url: "{{ wine_src_url }}"
+    dest: "{{ wine_src_path }}" 
+
+- name: Get sha256sum of the wine_staging file
+  stat:
+    path: "{{ wine_staging_path }}"
+    checksum_algorithm: sha256
+    get_checksum: yes
+  register: wine_staging_file
+
+- name: Save wine_staging file sha256 checksum
+  set_fact:
+    wine_staging_sha256: "{{ wine_staging_file.stat.checksum }}"
+
+- name: Get sha256sum of the wine src file
+  stat:
+    path: "{{ wine_src_path }}"
+    checksum_algorithm: sha256
+    get_checksum: yes
+  register: wine_staging_file
+
+- name: Save wine_src file sha256 checksum
+  set_fact:
+    wine_src_sha256: "{{ wine_staging_file.stat.checksum }}"

--- a/ansible_roles/get-wine-files-data/tests/inventory
+++ b/ansible_roles/get-wine-files-data/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/ansible_roles/get-wine-files-data/tests/test.yml
+++ b/ansible_roles/get-wine-files-data/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - get_wine_files_data


### PR DESCRIPTION
I've written some Ansible playbooks and roles to be able to add new versions of Wine to the repo just by running one command:

ansible-playbook ansible_add_latest_staging.yaml